### PR TITLE
Add workaround for Rocky8

### DIFF
--- a/bin/launch-vm.sh
+++ b/bin/launch-vm.sh
@@ -189,9 +189,10 @@ vm-setup() {
         --virt-type kvm \
         --import \
         --qemu-commandline='-smbios type=1,serial=ds=nocloud;h='"${VMNAME}"'.'"${DOMAIN}"'' \
-        --console "${CONSOLE}" \
+        --wait \
+        --noautoconsole \
         --video none \
-        --graphics none
+        --console "${CONSOLE}"
 
     virsh detach-disk --domain "${VMNAME}" "$(virsh dumpxml --domain "${VMNAME}" | xmllint --xpath "/domain/devices/disk/source/@file" - | cut -f 2-2 -d\" | grep -E iso\$)" --persistent --config
     rm "${LVSEED}/${VMNAME}.iso"

--- a/templates/rocky8.ini
+++ b/templates/rocky8.ini
@@ -1,4 +1,4 @@
-URL=https://download.rockylinux.org/pub/rocky/8.6/images/Rocky-8-GenericCloud.latest.x86_64.qcow2
+URL=https://dl.rockylinux.org/pub/rocky/8.6/images/Rocky-8-GenericCloud.latest.x86_64.qcow2
 SOURCE=source-rocky8.img
 OSVARIANT=centos8
 CONSOLE="pty,target_type=virtio"


### PR DESCRIPTION
Create VM without disabling video output, this fixes the boot of Rocky Linux 8